### PR TITLE
Potential fix for code scanning alert no. 3: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/ruby/src/home.rb
+++ b/ruby/src/home.rb
@@ -12,7 +12,7 @@ class Home < Application
   def run
     write_home_template
     update_home_passage
-    IO.write(path_to_home, home_passage.join.chomp)
+    File.write(path_to_home, home_passage.join.chomp)
     HOME_URL
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/hayat01sh1da/github-wiki-organisers/security/code-scanning/3](https://github.com/hayat01sh1da/github-wiki-organisers/security/code-scanning/3)

To fix the problem, we need to replace the use of `IO.write` with `File.write`. This change will mitigate the risk of arbitrary code execution by ensuring that the file path is not interpreted as a shell command. The change should be made in the `run` method of the `Home` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
