### PR TITLE
Potential fix for code scanning alert no. 4: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/ruby/src/sidebar.rb
+++ b/ruby/src/sidebar.rb
@@ -9,7 +9,7 @@ class Sidebar < Application
 
   def run
     update_wiki_list
-    IO.write(path_to_sidebar, wiki_list.join)
+    File.write(path_to_sidebar, wiki_list.join)
   end
 
   private


### PR DESCRIPTION
Potential fix for [https://github.com/hayat01sh1da/github-wiki-organisers/security/code-scanning/4](https://github.com/hayat01sh1da/github-wiki-organisers/security/code-scanning/4)

To fix the problem, we should replace the use of `IO.write` with `File.write`. This change will ensure that the file writing operation does not inadvertently execute arbitrary code. The change should be made in the `run` method of the `Sidebar` class, specifically on line 12.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
