### PR TITLE
Add Workflow For Llm To Ingore Wiki List

### DIFF
--- a/.github/workflows/export-unknown-wiki-list-for-llm.yml
+++ b/.github/workflows/export-unknown-wiki-list-for-llm.yml
@@ -1,0 +1,74 @@
+name: Export Unknown Wiki List for LLM
+
+on:
+  schedule:
+    # 00:00 JST every weekday
+    # ⚠️ The timing is somehow not accurate at all
+    - cron: "0 15 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout the Main Repository
+        uses: actions/checkout@v2
+        with:
+          repository: "${{ github.repository }}"
+          ref: master
+          path: ./github-wiki-organisers
+      - name: Checkout the Wiki Repository
+        uses: actions/checkout@v2
+        with:
+          repository: "${{ github.repository }}.wiki"
+          ref: master
+          path: ./github-wiki-organisers/wiki
+      - name: Configure Git Identity
+        working-directory: ./github-wiki-organisers/wiki
+        run: |
+          set -xe
+          git config --global user.name  "GitHub Actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.5
+      - name: Export Unknown Wiki List for LLM
+        working-directory: ./github-wiki-organisers/wiki
+        run: |
+          set -xe
+          git pull origin master
+          bash export_unknown_wiki_list_for_llm.sh
+          git add -A
+          current_time=$(TZ=Asia/Tokyo date "+%Y-%m-%d %H:%M:%S")
+          git commit -m "Commit unknown_wiki_list_for_llm.txt by GitHub Actions[bot] at $current_time" || true
+          git push origin master || true
+          echo COMMIT_MESSAGE=$(git log --oneline -1) >> $GITHUB_ENV
+          echo CURRENT_TIME=$current_time >> $GITHUB_ENV
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@v2
+        if: contains(env.COMMIT_MESSAGE, env.CURRENT_TIME)
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_APP_TOKEN }}
+          payload: |
+            channel: "C06S7N0Q2HE"
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: "【github-wiki-organisers Wiki LLM 取込み除外リスト出力通知】"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "Message: 最新の LLM 取込み除外リストを出力しました！${{ github.repository }}.wiki を Clone してご確認ください。"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "Workflows: <https://github.com/quipper/github-wiki-organisers/actions/workflows/export-unknown-wiki-list-for-llm.yml|Export Unknown Wiki List for LLM>"

--- a/python/README.md
+++ b/python/README.md
@@ -100,6 +100,17 @@ Check it out result on '../../unknown_wiki_count_list_by_namespace.txt' !!
 -------------------- Done Exporting Unknown Wiki Count List 🎉 --------------------
 ```
 
+## 2-4. Export Unknown Wiki List for LLM 
+
+```command
+$ python exec/export_unknown_wiki_list_for_llm.py
+-------------------- Exporting Unknown Wiki List... --------------------
+
+Check it out result on '../../export_unknown_wiki_list_for_llm.txt' !!
+
+-------------------- Done Exporting Unknown Wiki List 🎉 --------------------
+```
+
 ## 3. Bulk Execution of Unit Tests
 
 ```command

--- a/python/exec/export_unknown_wiki_list_for_llm.py
+++ b/python/exec/export_unknown_wiki_list_for_llm.py
@@ -1,0 +1,26 @@
+import sys
+import os
+import shutil
+import glob
+sys.path.append('./src')
+
+from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
+
+_, genre, language, *_ = sys.argv
+
+print('-------------------- Exporting Unknown Wiki List... --------------------')
+match genre:
+    case '-o' | '--owner' | '-c' | '--category':
+        match language:
+            case '-en' | '-ja':
+                path_to_export = UnknownWikiListExporterForLLM(genre = genre, language = language).run()
+    case _:
+        path_to_export = UnknownWikiListExporterForLLM().run()
+print()
+print("Check it out result on '#{path_to_export}' !!")
+print()
+print('-------------------- Done Exporting Unknown Wiki List 🎉 --------------------')
+
+for pycache in glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True):
+    if os.path.exists(pycache):
+        shutil.rmtree(pycache)

--- a/python/src/unknown_wiki_list_exporter_for_llm.py
+++ b/python/src/unknown_wiki_list_exporter_for_llm.py
@@ -1,0 +1,45 @@
+import sys
+import os
+sys.path.append('./src')
+from application import Application
+
+class UnknownWikiListExporterForLLM(Application):
+    def __init__(self, base_path = os.path.join('..', '..'), genre = '-o', language = '-en'):
+        super().__init__(base_path, genre, language)
+        self.path_to_export               = os.path.join(self.base_path, 'unknown_wiki_list_for_llm.txt')
+        self.unknown_wiki_list_for_llm = ''.join(sorted(self.__unknown_wiki_list_for_llm__()))
+
+    def run(self):
+        with open(self.path_to_export, 'w') as f:
+            f.write(self.unknown_wiki_list_for_llm.rstrip() + '\n')
+
+        return self.path_to_export
+
+    # private
+
+    # @return [str]
+    def __target_namespace__(self):
+        match self.genre:
+            case '-o' | '--owner':
+                match self.language:
+                    case '-en':
+                        return 'Unknown Owner nor Necessity'
+                    case '-ja':
+                        return 'Ownerチーム・要or不要が不明なページ群'
+            case '-c' | '--category':
+                match self.language:
+                    case '-en':
+                        return 'Uncategorised'
+                    case '-ja':
+                        return 'Category記載なし'
+
+    # @return [list<str>]
+    def __unknown_wiki_list_for_llm__(self):
+        unknown_wiki_list_for_llm = []
+
+        for namespace, wikis in self.plain_wiki_maps.items():
+            if namespace == self.__target_namespace__():
+                for wiki in wikis:
+                    unknown_wiki_list_for_llm.append(f'{wiki}\n')
+
+        return unknown_wiki_list_for_llm

--- a/python/test/test_unknown_wiki_list_exporter_for_llm.py
+++ b/python/test/test_unknown_wiki_list_exporter_for_llm.py
@@ -1,0 +1,73 @@
+import sys
+import os
+import unittest
+sys.path.append('./src')
+sys.path.append('./test')
+from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
+from test_application import TestApplication
+
+class TestUnknownWikiListExporterForLLM(TestApplication):
+    def setUp(self, genre = '-o', language = '-en'):
+        super().setUp(genre = genre, language = language)
+        UnknownWikiListExporterForLLM(base_path = self.base_path, genre = genre, language = language).run()
+        path_to_unknown_wiki_list_for_llm = os.path.join(self.base_path, 'unknown_wiki_list_for_llm.txt')
+        with open(path_to_unknown_wiki_list_for_llm) as f:
+            self.unknown_wiki_list_for_llm = f.read()
+
+class EnglishOwnershipTest(TestUnknownWikiListExporterForLLM):
+    def test_run(self):
+        self.assertEqual(self.unknown_wiki_list_for_llm, self.__unknown_wiki_list_for_llm__())
+
+    # private
+
+    def __unknown_wiki_list_for_llm__(self):
+        return 'Unknown Owner nor Necessity Wiki.md\n'
+
+class EnglishCategoryTest(TestUnknownWikiListExporterForLLM):
+    def setUp(self):
+        super().setUp(genre = '-c')
+
+    def test_run(self):
+        self.assertEqual(self.unknown_wiki_list_for_llm, ''.join(self.__unknown_wiki_list_for_llm__()))
+
+    # private
+
+    def __unknown_wiki_list_for_llm__(self):
+        lst = [
+            'Uncategorised Wiki 1.md\n',
+            'Uncategorised Wiki 2.md\n'
+        ]
+
+        return lst
+
+class JapaneseOwnershipTest(TestUnknownWikiListExporterForLLM):
+    def setUp(self):
+        super().setUp(genre = '-o', language = '-ja')
+
+    def test_run(self):
+        self.assertEqual(self.unknown_wiki_list_for_llm, self.__unknown_wiki_list_for_llm__())
+
+    # private
+
+    def __unknown_wiki_list_for_llm__(self):
+        return 'Ownerチーム・要or不要が不明なページ.md\n'
+
+class JapaneseCategoryTest(TestUnknownWikiListExporterForLLM):
+    def setUp(self):
+        super().setUp(genre = '-c', language = '-ja')
+
+    def test_run(self):
+        self.assertEqual(self.unknown_wiki_list_for_llm, ''.join(self.__unknown_wiki_list_for_llm__()))
+
+    # private
+
+    def __unknown_wiki_list_for_llm__(self):
+        lst = [
+            'Category記載なしページ1.md\n',
+            'Category記載なしページ2.md\n'
+        ]
+
+        return lst
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -98,6 +98,17 @@ Check it out result on '../../unknown_wiki_count_list_by_namespace.txt' !!
 -------------------- Done Exporting Unknown Wiki Count List 🎉 --------------------
 ```
 
+## 2-4. Export Unknown Wiki List for LLM 
+
+```command
+$ ruby exec/export_unknown_wiki_list_for_llm.rb
+-------------------- Exporting Unknown Wiki List... --------------------
+
+Check it out result on '../../export_unknown_wiki_list_for_llm.txt' !!
+
+-------------------- Done Exporting Unknown Wiki List 🎉 --------------------
+```
+
 ## 3. Bulk Execution of Unit Tests
 
 ```command

--- a/ruby/exec/export_unknown_wiki_list_for_llm.rb
+++ b/ruby/exec/export_unknown_wiki_list_for_llm.rb
@@ -1,0 +1,18 @@
+require_relative '../src/unknown_wiki_list_exporter_for_llm'
+
+genre, language, *_ = ARGV
+
+puts '-------------------- Exporting Unknown Wiki List... --------------------'
+path_to_export = case genre
+when '-o', '--owner', '-c', '--category'
+  case language
+  when '-en', '-ja'
+    UnknownWikiListExporterForLLM.run(genre:, language:)
+  end
+else
+  UnknownWikiListExporterForLLM.run
+end
+puts "\n"
+puts "Check it out result on '#{path_to_export}' !!"
+puts "\n"
+puts '-------------------- Done Exporting Unknown Wiki List 🎉 --------------------'

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -1,0 +1,46 @@
+require_relative './application'
+
+class UnknownWikiListExporterForLLM < Application
+  def initialize(base_path:, genre:, language:)
+    super(base_path:, genre:, language:)
+    @path_to_export = File.join(base_path, 'unknown_wiki_list_for_llm.txt')
+  end
+
+  def run
+    File.open(path_to_export, 'wb') { |f| f.puts(unknown_wiki_list_for_llm) }
+    path_to_export
+  end
+
+  private
+
+  attr_reader :path_to_export
+
+  # @return [Array<String>]
+  def target_namespace
+    case genre
+    when '-o', '--owner'
+      case language
+      when '-en'
+        'Unknown Owner nor Necessity'
+      when '-ja'
+        'Ownerチーム・要or不要が不明なページ群'
+      end
+    when '-c', '--category'
+      case language
+      when '-en'
+        'Uncategorised'
+      when '-ja'
+        'Category記載なし'
+      end
+    end
+  end
+
+  # @return [Array<String>]
+  def unknown_wiki_list_for_llm
+    @unknown_wiki_list_for_llm ||= plain_wiki_maps.select { |namespace, _|
+      target_namespace.include?(namespace)
+    }.then {
+      it.values.flatten
+    }
+  end
+end

--- a/ruby/test/unknown_wiki_list_exporter_for_llm_test.rb
+++ b/ruby/test/unknown_wiki_list_exporter_for_llm_test.rb
@@ -6,7 +6,7 @@ class UnknownWikiListExporterForLLMTest < ApplicationTest
     super(genre:, language:)
     UnknownWikiListExporterForLLM.run(base_path:, genre:, language:)
     @path_to_unknown_wiki_list_for_llm = File.join(base_path, 'unknown_wiki_list_for_llm.txt')
-    @unknown_wiki_list_for_llm         = IO.read(path_to_unknown_wiki_list_for_llm)
+    @unknown_wiki_list_for_llm         = File.read(path_to_unknown_wiki_list_for_llm)
   end
 
   private

--- a/ruby/test/unknown_wiki_list_exporter_for_llm_test.rb
+++ b/ruby/test/unknown_wiki_list_exporter_for_llm_test.rb
@@ -1,0 +1,89 @@
+require_relative './application_test'
+require_relative '../src/unknown_wiki_list_exporter_for_llm'
+
+class UnknownWikiListExporterForLLMTest < ApplicationTest
+  def setup(genre: '-o', language: '-en')
+    super(genre:, language:)
+    UnknownWikiListExporterForLLM.run(base_path:, genre:, language:)
+    @path_to_unknown_wiki_list_for_llm = File.join(base_path, 'unknown_wiki_list_for_llm.txt')
+    @unknown_wiki_list_for_llm         = IO.read(path_to_unknown_wiki_list_for_llm)
+  end
+
+  private
+
+  attr_reader :path_to_unknown_wiki_list_for_llm, :unknown_wiki_list_for_llm
+end
+
+module English
+  class UnknownWikiListExporterForLLMTest::OwnershipTest < UnknownWikiListExporterForLLMTest
+    def test_self_run
+      assert_equal(unknown_wiki_list.join("\n"), unknown_wiki_list_for_llm.chomp)
+    end
+
+    private
+
+    def unknown_wiki_list
+      [
+        'Unknown Owner nor Necessity Wiki.md'
+      ]
+    end
+  end
+
+  class UnknownWikiListExporterForLLMTest::CategoryTest < UnknownWikiListExporterForLLMTest
+    def setup
+      super(genre: '-c')
+    end
+
+    def test_self_run
+      assert_equal(unknown_wiki_list.join("\n"), unknown_wiki_list_for_llm.chomp)
+    end
+
+    private
+
+    def unknown_wiki_list
+      [
+        'Uncategorised Wiki 1.md',
+        'Uncategorised Wiki 2.md'
+      ]
+    end
+  end
+end
+
+module Japanese
+  class UnknownWikiListExporterForLLMTest::OwnershipTest < UnknownWikiListExporterForLLMTest
+    def setup
+      super(genre: '-o', language: '-ja')
+    end
+
+    def test_self_run
+      assert_equal(unknown_wiki_list.join("\n"), unknown_wiki_list_for_llm.chomp)
+    end
+
+    private
+
+    def unknown_wiki_list
+      [
+        'Ownerチーム・要or不要が不明なページ.md'
+      ]
+    end
+  end
+
+  class UnknownWikiListExporterForLLMTest::CategoryTest < UnknownWikiListExporterForLLMTest
+    def setup
+      super(genre: '-c', language: '-ja')
+    end
+
+    def test_self_run
+      assert_equal(unknown_wiki_list.join("\n"), unknown_wiki_list_for_llm.chomp)
+    end
+
+    private
+
+    def unknown_wiki_list
+      [
+        'Category記載なしページ1.md',
+        'Category記載なしページ2.md'
+      ]
+    end
+  end
+end


### PR DESCRIPTION
## 1. Summary

GitHub Wiki can be teacher data for LLM.
However, unowned or uncategorised pages can be noise.
Here is the GHA workflows which list up wikis categorised to them.

## 2. Commits

- [Commit UnknownWikiListExporterForLLM](https://github.com/hayat01sh1da/github-wiki-organisers/commit/fbf95c7df4820cd380147696e1d536dc09afe736)
- [Commit execution file](https://github.com/hayat01sh1da/github-wiki-organisers/commit/9c3c702a887dda04fa3e469036e32eae369428ec)
- [Commit GHA yaml](https://github.com/hayat01sh1da/github-wiki-organisers/commit/40022667ebeffbb235b77e8028c0753dd6aa1b8e)
- [Describe how to execute export of unknown list for LLM on READMEs](https://github.com/hayat01sh1da/github-wiki-organisers/commit/e4db6504114903c79e1187223f7b9674520c6ff7)
- [Potential fix for code scanning alert no. 8: Use of Kernel.open or IO.read or similar sinks with a non-constant value](https://github.com/hayat01sh1da/github-wiki-organisers/pull/8/commits/6f329f2de8d84734b2b6c381df50ea82502d1ba0)