### PR TITLE
[Enhancement] Optimise Interfaces for Home Overflow Parameter

### DIFF
--- a/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
+++ b/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
@@ -17,13 +17,18 @@ on:
           - Owner
           - Category
       language:
-        description: "Specify the language used for the wiki pages"
+        description: Specify the language used for the wiki pages
         required: true
         default: English
         type: choice
         options:
           - English
           - Japanese
+      home_overflow:
+        description: ⚠️ The wiki page took too long to render
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -60,7 +65,7 @@ jobs:
         run: |
           set -xe
           git pull origin master
-          bash update_wiki_list_on_home_and_sidebar.sh "${{ github.event.inputs.group_by }}" "${{ github.event.inputs.language }}"
+          bash update_wiki_list_on_home_and_sidebar.sh "${{ github.event.inputs.group_by }}" "${{ github.event.inputs.language }}" "${{ github.event.inputs.home_overflow }}"
           git add -A
           current_time=$(TZ=Asia/Tokyo date "+%Y-%m-%d %H:%M:%S")
           git commit -m "Update Wiki list on Home and Sidebar by GitHub Actions[bot] at $current_time" || true

--- a/python/README.md
+++ b/python/README.md
@@ -8,10 +8,11 @@ Run the commands under `./python`
 
 ### 2-1. Options
 
-|Order |Option   |Command-line Argument   |
-|:-----|:--------|:-----------------------|
-|1     |group_by |`Owner` or `Category`   |
-|2     |language |`English` or `Japanese` |
+|Order |Option        |Command-line Argument   |
+|:-----|:-------------|:-----------------------|
+|1     |group_by      |`Owner` or `Category`   |
+|2     |language      |`English` or `Japanese` |
+|3     |home_overflow |`True` or `False`       |
 
 ### 2-2. Update Wiki List on Home and Sidebar
 

--- a/python/exec/update_wiki_list_on_home_and_sidebar.py
+++ b/python/exec/update_wiki_list_on_home_and_sidebar.py
@@ -7,13 +7,16 @@ sys.path.append('./src')
 from home import Home
 from sidebar import Sidebar
 
-_, group_by, language, *_ = sys.argv
+_, group_by, language, home_overflow, *_ = sys.argv
 
 print('-------------------- Categorising the Entire github-wiki-organisers Wiki Pages... --------------------')
 print()
 print('-------------------- Organising Home... --------------------')
 match group_by:
-    case 'Owner' | 'Category':
+    case 'Owner':
+        if home_overflow == 'true':
+            home_url = Home(group_by = group_by, home_overflow = True).run()
+    case 'Category':
         home_url = Home(group_by = group_by).run()
 
         match language:

--- a/python/src/application.py
+++ b/python/src/application.py
@@ -4,11 +4,12 @@ import re
 from collections import defaultdict
 
 class Application:
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English'):
+    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
         self.__validate__(group_by = group_by, language = language)
         self.base_path                             = base_path
         self.group_by                              = group_by
         self.language                              = language
+        self.home_overflow                         = home_overflow
         self.path_to_home                          = os.path.join(base_path, 'Home.md')
         self.path_to_sidebar                       = os.path.join(base_path, '_Sidebar.md')
         self.target_paths                          = self.__target_paths__()

--- a/python/src/home.py
+++ b/python/src/home.py
@@ -8,15 +8,13 @@ from application import Application
 HOME_URL = f'https://github.com/{os.environ.get('ORGANISATION_NAME', 'hayat01sh1da')}/github-wiki-organisers/wiki'
 
 class Home(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English'):
-        super().__init__(base_path, group_by, language)
+    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+        super().__init__(base_path, group_by, language, home_overflow)
         self.base_owner_url = f'https://github.com/orgs/{os.environ.get('ORGANISATION_NAME', 'hayat01sh1da')}/teams/'
         self.home_passage   = self.__home_passage__()
 
     def run(self):
-        self.__update_home_template__()
-        with open(self.path_to_home, 'w') as f:
-            f.write(self.home_passage.rstrip() + '\n')
+        self.__write_home_passage__()
         return HOME_URL
 
     # private
@@ -31,17 +29,52 @@ class Home(Application):
             return f.read() + '\n'
 
     # @return [str]
-    def __update_home_template__(self):
-        for namespace, wikis in self.owned_wiki_maps.items():
-            self.home_passage += f'## [{namespace}]({self.base_owner_url + re.sub(r'@', '', namespace)})\n'
-            self.home_passage += '\n'
-            for wiki in wikis:
-                self.home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
-            self.home_passage += '\n'
+    def __write_home_passage__(self):
+        if self.home_overflow:
+            path_to_wikis_by_owners = os.path.join(self.base_path, 'wikis_by_owners')
+            if not os.path.exists(self.base_path):
+                os.makedirs(path_to_wikis_by_owners)
 
-        for namespace, wikis in self.plain_wiki_maps.items():
-            self.home_passage += f'## {namespace}\n'
-            self.home_passage += '\n'
-            for wiki in wikis:
-                self.home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
-            self.home_passage += '\n'
+            for namespace, wikis in self.owned_wiki_maps.items():
+                home_passage  = ''
+                home_passage += f'## [{namespace}]({self.base_owner_url + re.sub(r'@', '', namespace)})\n'
+                home_passage += '\n'
+                for wiki in wikis:
+                    home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
+                home_passage += '\n'
+                with open(path_to_wikis_by_owners, 'w') as f:
+                    f.write(home_passage.rstrip() + '\n')
+
+            for namespace, wikis in self.plain_wiki_maps.items():
+                home_passage  = ''
+                home_passage += f'## {namespace}\n'
+                home_passage += '\n'
+                for wiki in wikis:
+                    home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
+                home_passage += '\n'
+                with open(path_to_wikis_by_owners, 'w') as f:
+                    f.write(home_passage.rstrip() + '\n')
+
+            for namespace in self.owned_wiki_maps.keys():
+                self.home_passage += f'[[{namespace}]]'
+
+            for namespace in self.plain_wiki_maps.keys():
+                self.home_passage += f'[[{namespace}]]'
+
+        else:
+            for namespace, wikis in self.owned_wiki_maps.items():
+                self.home_passage += f'## [{namespace}]({self.base_owner_url + re.sub(r'@', '', namespace)})\n'
+                self.home_passage += '\n'
+                for wiki in wikis:
+                    self.home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
+                self.home_passage += '\n'
+
+            for namespace, wikis in self.plain_wiki_maps.items():
+                self.home_passage += f'## {namespace}\n'
+                self.home_passage += '\n'
+                for wiki in wikis:
+                    self.home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
+                self.home_passage += '\n'
+
+            with open(self.path_to_home, 'w') as f:
+                f.write(self.home_passage.rstrip() + '\n')

--- a/python/src/home.py
+++ b/python/src/home.py
@@ -30,7 +30,7 @@ class Home(Application):
 
     # @return [str]
     def __write_home_passage__(self):
-        if self.home_overflow:
+        if self.group_by == 'Owner' and self.home_overflow:
             path_to_wikis_by_owners = os.path.join(self.base_path, 'wikis_by_owners')
             if not os.path.exists(self.base_path):
                 os.makedirs(path_to_wikis_by_owners)
@@ -55,11 +55,13 @@ class Home(Application):
                 with open(path_to_wikis_by_owners, 'w') as f:
                     f.write(home_passage.rstrip() + '\n')
 
-            for namespace in self.owned_wiki_maps.keys():
-                self.home_passage += f'[[{namespace}]]'
+            for namespace in (list(self.owned_wiki_maps.keys()) + list(self.plain_wiki_maps.keys())):
+                self.home_passage += f'- [[{namespace}]]\n'
 
-            for namespace in self.plain_wiki_maps.keys():
-                self.home_passage += f'[[{namespace}]]'
+            self.home_passage += '\n'
+
+            with open(self.path_to_home, 'w') as f:
+                f.write(self.home_passage.rstrip() + '\n')
 
         else:
             for namespace, wikis in self.owned_wiki_maps.items():

--- a/python/src/sidebar.py
+++ b/python/src/sidebar.py
@@ -6,8 +6,8 @@ sys.path.append('./src')
 from application import Application
 
 class Sidebar(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English'):
-        super().__init__(base_path, group_by, language)
+    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+        super().__init__(base_path, group_by, language, home_overflow)
         self.base_owner_url = f'https://github.com/orgs/{os.environ.get('ORGANISATION_NAME', 'hayat01sh1da')}/teams/'
         self.wiki_list      = self.__write_wiki_list__()
 

--- a/python/src/unknown_wiki_count_list_exporter.py
+++ b/python/src/unknown_wiki_count_list_exporter.py
@@ -5,8 +5,8 @@ sys.path.append('./src')
 from application import Application
 
 class UnknownWikiCountListExporter(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English'):
-        super().__init__(base_path, group_by, language)
+    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+        super().__init__(base_path, group_by, language, home_overflow)
         self.path_to_export          = os.path.join(self.base_path, 'unknown_wiki_count_list_by_namespace.txt')
         self.count_list_by_namespace = ''.join(sorted(self.__count_list_by_namespace__()))
 

--- a/python/src/unknown_wiki_list_exporter_for_llm.py
+++ b/python/src/unknown_wiki_list_exporter_for_llm.py
@@ -4,8 +4,8 @@ sys.path.append('./src')
 from application import Application
 
 class UnknownWikiListExporterForLLM(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English'):
-        super().__init__(base_path, group_by, language)
+    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+        super().__init__(base_path, group_by, language, home_overflow)
         self.path_to_export               = os.path.join(self.base_path, 'unknown_wiki_list_for_llm.txt')
         self.unknown_wiki_list_for_llm = ''.join(sorted(self.__unknown_wiki_list_for_llm__()))
 

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -8,10 +8,11 @@ sys.path.append('./src')
 from application import Application
 
 class TestApplication(unittest.TestCase):
-    def setUp(self, base_path = os.path.join('.', 'test', 'wiki'), group_by = 'Owner', language = 'English'):
-        self.base_path = base_path
-        self.group_by  = group_by
-        self.language  = language
+    def setUp(self, base_path = os.path.join('.', 'test', 'wiki'), group_by = 'Owner', language = 'English', home_overflow = False):
+        self.base_path      = base_path
+        self.group_by       = group_by
+        self.language       = language
+        self.home_overflow  = home_overflow
         self.pycaches  = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
         if not os.path.exists(self.base_path):
             os.makedirs(self.base_path)
@@ -28,17 +29,17 @@ class TestApplication(unittest.TestCase):
 
     def test_validate_group_by(self):
         with self.assertRaises(ValueError) as e:
-            Application(base_path = self.base_path, group_by = 'Group', language = self.language)
+            Application(base_path = self.base_path, group_by = 'Group', language = self.language, home_overflow = self.home_overflow)
         self.assertEqual(str(e.exception), 'Invalid group_by: `Group`')
 
     def test_validate_language(self):
         with self.assertRaises(ValueError) as e:
-            Application(base_path = self.base_path, group_by = self.group_by, language = 'Spanish')
+            Application(base_path = self.base_path, group_by = self.group_by, language = 'Spanish', home_overflow = self.home_overflow)
         self.assertEqual(str(e.exception), 'Invalid language: `Spanish`')
 
     def test_run(self):
         with self.assertRaises(NotImplementedError, msg = 'This method must be implemented in each subclass.'):
-            Application(base_path = self.base_path, group_by = self.group_by, language = self.language).run()
+            Application(base_path = self.base_path, group_by = self.group_by, language = self.language, home_overflow = self.home_overflow).run()
 
     # private
 

--- a/python/test/test_home.py
+++ b/python/test/test_home.py
@@ -15,7 +15,7 @@ class TestHome(TestApplication):
         with open(path_to_home) as f:
             self.home = f.read()
 
-class EnglishOwnedHomeTest(TestHome):
+class EnglishOwnedHomeWithoutOverflowTest(TestHome):
     def test_run(self):
         self.assertEqual(self.home, self.__home_passage__())
 
@@ -50,6 +50,32 @@ class EnglishOwnedHomeTest(TestHome):
 
         return passage
 
+class EnglishOwnedHomeWithOverflowTest(TestHome):
+    def setUp(self):
+        super().setUp(home_overflow = True)
+
+    def test_run(self):
+        self.assertEqual(self.home, self.__home_passage__())
+
+    # private
+
+    def __home_passage__(self):
+        passage  = '## How to Manage Wiki Pages\n'
+        passage += '\n'
+        passage += 'This Home page manage wikis by owner group.\n'
+        passage += '\n'
+        passage += 'Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n'
+        passage += 'Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n'
+        passage += '\n'
+        passage += 'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
+        passage += '\n'
+        passage += '- [[@test-owner]]\n'
+        passage += '- [[Unknown Owner nor Necessity]]\n'
+        passage += '- [[Unowned but Necessary]]\n'
+        passage += '- [[Unowned]]\n'
+
+        return passage
+
 class EnglishCategorisedHomeTest(TestHome):
     def setUp(self):
         super().setUp(group_by = 'Category')
@@ -80,7 +106,7 @@ class EnglishCategorisedHomeTest(TestHome):
 
         return passage
 
-class JapaneseOwnedHomeTest(TestHome):
+class JapaneseOwnedHomeWithoutOverflowTest(TestHome):
     def setUp(self):
         super().setUp(language = 'Japanese')
 
@@ -115,6 +141,32 @@ class JapaneseOwnedHomeTest(TestHome):
         passage += '\n'
         passage += '- [[Owner記名なしページ1]]\n'
         passage += '- [[Owner記名なしページ2]]\n'
+
+        return passage
+
+class JapaneseOwnedHomeWihOverflowTest(TestHome):
+    def setUp(self):
+        super().setUp(language = 'Japanese', home_overflow = True)
+
+    def test_run(self):
+        self.assertEqual(self.home, self.__home_passage__())
+
+    # private
+
+    def __home_passage__(self):
+        passage  = '## Wiki ページの運用ルール\n'
+        passage += '\n'
+        passage += 'このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n'
+        passage += '\n'
+        passage += 'Ownership をどのチームが持つのかが不明だと、責任の所在が不明瞭になり、保守性の悪化に伴うノイズの増加と検索性の悪化が発生します。  \n'
+        passage += '治安維持のため、各ページの冒頭に `Owner: @オーナーチーム` を明記して頂きますようよろしくお願いします。\n'
+        passage += '\n'
+        passage += 'なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n'
+        passage += '\n'
+        passage += '- [[@test-owner]]\n'
+        passage += '- [[Ownerチームが不明だが必要なページ群]]\n'
+        passage += '- [[Ownerチーム・要or不要が不明なページ群]]\n'
+        passage += '- [[Owner記名なし]]\n'
 
         return passage
 

--- a/python/test/test_home.py
+++ b/python/test/test_home.py
@@ -8,9 +8,9 @@ from home import Home
 from test_application import TestApplication
 
 class TestHome(TestApplication):
-    def setUp(self, group_by = 'Owner', language = 'English'):
-        super().setUp(group_by = group_by, language = language)
-        Home(base_path = self.base_path, group_by = group_by, language = language).run()
+    def setUp(self, group_by = 'Owner', language = 'English', home_overflow = False):
+        super().setUp(group_by = group_by, language = language, home_overflow = home_overflow)
+        Home(base_path = self.base_path, group_by = group_by, language = language, home_overflow = home_overflow).run()
         path_to_home = os.path.join(self.base_path, 'Home.md')
         with open(path_to_home) as f:
             self.home = f.read()

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -8,10 +8,11 @@ Run the commands under `./ruby`
 
 ### 2-1. Options
 
-|Order |Option   |Command-line Argument   |
-|:-----|:--------|:-----------------------|
-|1     |group_by |`Owner` or `Category`   |
-|2     |language |`English` or `Japanese` |
+|Order |Option        |Command-line Argument   |
+|:-----|:-------------|:-----------------------|
+|1     |group_by      |`Owner` or `Category`   |
+|2     |language      |`English` or `Japanese` |
+|3     |home_overflow |`true` or `false`       |
 
 ### 2-2. Update Wiki List on Home and Sidebar
 

--- a/ruby/exec/update_wiki_list_on_home_and_sidebar.rb
+++ b/ruby/exec/update_wiki_list_on_home_and_sidebar.rb
@@ -1,13 +1,16 @@
 require_relative '../src/home'
 require_relative '../src/sidebar'
 
-group_by, language, *_ = ARGV
+group_by, language, home_overflow, *_ = ARGV
 
 puts '-------------------- Categorising the Entire github-wiki-organisers Wiki Pages... --------------------'
 puts "\n"
 puts '-------------------- Organising Home... --------------------'
 home_url = case group_by
-when 'Owner', 'Category'
+when 'Owner'
+  if home_overflow
+    Home.run(group_by:, home_overflow:)
+when 'Category'
   Home.run(group_by:)
 
   case language

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -1,16 +1,17 @@
 class Application
   class NotImplementedError < StandardError; end
 
-  def self.run(base_path: File.join('..', '..'), group_by: 'Owner', language: 'English')
-    instance = new(base_path:, group_by:, language:)
+  def self.run(base_path: File.join('..', '..'), group_by: 'Owner', language: 'English', home_overflow: false)
+    instance = new(base_path:, group_by:, language:, home_overflow:)
     instance.validate!
     instance.run
   end
 
-  def initialize(base_path:, group_by:, language:)
+  def initialize(base_path:, group_by:, language:, home_overflow:)
+    @base_path       = base_path
     @group_by        = group_by
     @language        = language
-    @base_path       = base_path
+    @home_overflow   = home_overflow
     @path_to_home    = File.join(base_path, 'Home.md')
     @path_to_sidebar = File.join(base_path, '_Sidebar.md')
     @paths_to_wikis  = Dir[File.join(base_path, '**', '*.md')].sort
@@ -27,7 +28,7 @@ class Application
 
   private
 
-  attr_reader :group_by, :language, :base_path, :path_to_home, :path_to_sidebar, :paths_to_wikis
+  attr_reader :base_path, :group_by, :language, :home_overflow, :path_to_home, :path_to_sidebar, :paths_to_wikis
 
   # @return [String]
   def target_paths

--- a/ruby/src/home.rb
+++ b/ruby/src/home.rb
@@ -29,7 +29,7 @@ class Home < Application
 
   # @return nil
   def write_home_passage
-    if home_overflow
+    if group_by == 'Owner' && home_overflow
       path_to_wikis_by_owners = File.join(base_path, 'wikis_by_owners')
       FileUtils.mkdir_p(path_to_wikis_by_owners) unless Dir.exist?(path_to_wikis_by_owners)
 
@@ -57,14 +57,8 @@ class Home < Application
         File.write(File.join(path_to_wikis_by_owners,"#{namespace}.md"), home_passage.join.chomp)
       }
 
-      owned_wiki_maps.keys.each { |namespace|
-        home_passage << - "[[#{namespace}]]"
-      }
-
-      plain_wiki_maps.keys.each { |namespace|
-        home_passage << - "[[#{namespace}]]"
-      }
-
+      (owned_wiki_maps.keys + plain_wiki_maps.keys).each { |namespace| home_passage << "- [[#{namespace}]]\n" }
+      home_passage << "\n"
       File.write(path_to_home, home_passage.join.chomp)
     else
       owned_wiki_maps.each { |namespace, wikis|

--- a/ruby/src/home.rb
+++ b/ruby/src/home.rb
@@ -3,14 +3,13 @@ require_relative './application'
 class Home < Application
   HOME_URL = "https://github.com/#{ENV.fetch('ORGANISATION_NAME', 'hayat01sh1da')}/github-wiki-organisers/wiki".freeze
 
-  def initialize(base_path:, group_by:, language:)
-    super(base_path:, group_by:, language:)
+  def initialize(base_path:, group_by:, language:, home_overflow:)
+    super(base_path:, group_by:, language:, home_overflow:)
     @base_owner_url = "https://github.com/orgs/#{ENV.fetch('ORGANISATION_NAME', 'hayat01sh1da')}/teams/"
   end
 
   def run
-    update_home_passage
-    File.write(path_to_home, home_passage.join.chomp)
+    write_home_passage
     HOME_URL
   end
 
@@ -29,23 +28,64 @@ class Home < Application
   end
 
   # @return nil
-  def update_home_passage
-    owned_wiki_maps.each { |namespace, wikis|
-      home_passage << "## [#{namespace}](#{base_owner_url + namespace.gsub(/\@/, '')})\n"
-      home_passage << "\n"
-      wikis.each { |wiki|
-        home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
-      }
-      home_passage << "\n"
-    }
+  def write_home_passage
+    if home_overflow
+      path_to_wikis_by_owners = File.join(base_path, 'wikis_by_owners')
+      FileUtils.mkdir_p(path_to_wikis_by_owners) unless Dir.exist?(path_to_wikis_by_owners)
 
-    plain_wiki_maps.each { |namespace, wikis|
-      home_passage << "## #{namespace}\n"
-      home_passage << "\n"
-      wikis.each { |wiki|
-        home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
+      owned_wiki_maps.each { |namespace, wikis|
+        home_passage  = []
+        home_passage << "## [#{namespace}](#{base_owner_url + namespace.gsub(/\@/, '')})\n"
+        home_passage << "\n"
+        wikis.each { |wiki|
+          home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
+        }
+        home_passage << "\n"
+
+        File.write(File.join(path_to_wikis_by_owners,"#{namespace}.md"), home_passage.join.chomp)
       }
-      home_passage << "\n"
-    }
+
+      plain_wiki_maps.each { |namespace, wikis|
+        home_passage  = []
+        home_passage << "## #{namespace}\n"
+        home_passage << "\n"
+        wikis.each { |wiki|
+          home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
+        }
+        home_passage << "\n"
+
+        File.write(File.join(path_to_wikis_by_owners,"#{namespace}.md"), home_passage.join.chomp)
+      }
+
+      owned_wiki_maps.keys.each { |namespace|
+        home_passage << - "[[#{namespace}]]"
+      }
+
+      plain_wiki_maps.keys.each { |namespace|
+        home_passage << - "[[#{namespace}]]"
+      }
+
+      File.write(path_to_home, home_passage.join.chomp)
+    else
+      owned_wiki_maps.each { |namespace, wikis|
+        home_passage << "## [#{namespace}](#{base_owner_url + namespace.gsub(/\@/, '')})\n"
+        home_passage << "\n"
+        wikis.each { |wiki|
+          home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
+        }
+        home_passage << "\n"
+      }
+
+      plain_wiki_maps.each { |namespace, wikis|
+        home_passage << "## #{namespace}\n"
+        home_passage << "\n"
+        wikis.each { |wiki|
+          home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
+        }
+        home_passage << "\n"
+      }
+
+      File.write(path_to_home, home_passage.join.chomp)
+    end
   end
 end

--- a/ruby/src/sidebar.rb
+++ b/ruby/src/sidebar.rb
@@ -1,8 +1,8 @@
 require_relative './application'
 
 class Sidebar < Application
-  def initialize(base_path:, group_by:, language:)
-    super(base_path:, group_by:, language:)
+  def initialize(base_path:, group_by:, language:, home_overflow: false)
+    super(base_path:, group_by:, language:, home_overflow:)
     @base_owner_url = "https://github.com/orgs/#{ENV.fetch('ORGANISATION_NAME', 'hayat01sh1da')}/teams/"
     @wiki_list      = []
   end

--- a/ruby/src/unknown_wiki_count_list_exporter.rb
+++ b/ruby/src/unknown_wiki_count_list_exporter.rb
@@ -1,8 +1,8 @@
 require_relative './application'
 
 class UnknownWikiCountListExporter < Application
-  def initialize(base_path:, group_by:, language:)
-    super(base_path:, group_by:, language:)
+  def initialize(base_path:, group_by:, language:, home_overflow: false)
+    super(base_path:, group_by:, language:, home_overflow:)
     @path_to_export = File.join(base_path, 'unknown_wiki_count_list_by_namespace.txt')
   end
 

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -1,8 +1,8 @@
 require_relative './application'
 
 class UnknownWikiListExporterForLLM < Application
-  def initialize(base_path:, group_by:, language:)
-    super(base_path:, group_by:, language:)
+  def initialize(base_path:, group_by:, language:, home_overflow: false)
+    super(base_path:, group_by:, language:, home_overflow:)
     @path_to_export = File.join(base_path, 'unknown_wiki_list_for_llm.txt')
   end
 

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -3,10 +3,11 @@ require 'fileutils'
 require_relative '../src/application'
 
 class ApplicationTest < Minitest::Test
-  def setup(base_path: File.join('.', 'test', 'wiki'), group_by: 'Owner', language: 'English')
-    @base_path = base_path
-    @group_by  = group_by
-    @language  = language
+  def setup(base_path: File.join('.', 'test', 'wiki'), group_by: 'Owner', language: 'English', home_overflow: false)
+    @base_path     = base_path
+    @group_by      = group_by
+    @language      = language
+    @home_overflow = home_overflow
     FileUtils.mkdir_p(base_path) unless Dir.exist?(base_path)
     test_file_maps.each { |wiki, namespace|
       File.write(File.join(base_path, wiki), namespace)
@@ -19,28 +20,28 @@ class ApplicationTest < Minitest::Test
 
   def test_validate_group_by!
     error = assert_raises ArgumentError do
-      Application.new(base_path:, group_by: 'Group', language:).validate!
+      Application.new(base_path:, group_by: 'Group', language:, home_overflow:).validate!
     end
     assert_equal('Invalid group_by: `Group`', error.message)
   end
 
   def test_validate_language!
     error = assert_raises ArgumentError do
-      Application.new(base_path:, group_by: 'Owner', language: 'Spanish').validate!
+      Application.new(base_path:, group_by: 'Owner', language: 'Spanish', home_overflow:).validate!
     end
     assert_equal('Invalid language: `Spanish`', error.message)
   end
 
   def test_self_run
     error = assert_raises Application::NotImplementedError do
-      Application.run(base_path:, group_by:)
+      Application.run(base_path:)
     end
     assert_equal('This method must be implemented in each subclass.', error.message)
   end
 
   private
 
-  attr_reader :base_path, :group_by, :language
+  attr_reader :base_path, :group_by, :language, :home_overflow
 
   def test_file_maps
     case group_by

--- a/ruby/test/home_test.rb
+++ b/ruby/test/home_test.rb
@@ -15,40 +15,72 @@ class HomeTest < ApplicationTest
 
   module English
     class OwnedHomeTest < HomeTest
-      def test_self_run
-        assert_equal(home_passage.join, home)
+      class NonOverflowTest < HomeTest
+        def test_self_run
+          assert_equal(home_passage.join, home)
+        end
+
+        private
+
+        def home_passage
+          [
+            "## How to Manage Wiki Pages\n",
+            "\n",
+            "This Home page manage wikis by owner group.\n",
+            "\n",
+            "Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n",
+            "Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n",
+            "\n",
+            "Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n",
+            "\n",
+            "## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n",
+            "\n",
+            "- [[Owned Wiki]]\n",
+            "\n",
+            "## Unknown Owner nor Necessity\n",
+            "\n",
+            "- [[Unknown Owner nor Necessity Wiki]]\n",
+            "\n",
+            "## Unowned but Necessary\n",
+            "\n",
+            "- [[Unowned but Necessary Wiki]]\n",
+            "\n",
+            "## Unowned\n",
+            "\n",
+            "- [[Unowned Wiki 1]]\n",
+            "- [[Unowned Wiki 2]]\n"
+          ]
+        end
       end
 
-      private
+      class OverflowTest < HomeTest
+        def setup
+          super(home_overflow: true)
+        end
 
-      def home_passage
-        [
-          "## How to Manage Wiki Pages\n",
-          "\n",
-          "This Home page manage wikis by owner group.\n",
-          "\n",
-          "Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n",
-          "Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n",
-          "\n",
-          "Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n",
-          "\n",
-          "## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n",
-          "\n",
-          "- [[Owned Wiki]]\n",
-          "\n",
-          "## Unknown Owner nor Necessity\n",
-          "\n",
-          "- [[Unknown Owner nor Necessity Wiki]]\n",
-          "\n",
-          "## Unowned but Necessary\n",
-          "\n",
-          "- [[Unowned but Necessary Wiki]]\n",
-          "\n",
-          "## Unowned\n",
-          "\n",
-          "- [[Unowned Wiki 1]]\n",
-          "- [[Unowned Wiki 2]]\n"
-        ]
+        def test_self_run
+          assert_equal(home_passage.join, home)
+        end
+
+        private
+
+        def home_passage
+          [
+            "## How to Manage Wiki Pages\n",
+            "\n",
+            "This Home page manage wikis by owner group.\n",
+            "\n",
+            "Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n",
+            "Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n",
+            "\n",
+            "Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n",
+            "\n",
+            "- [[@test-owner]]\n",
+            "- [[Unknown Owner nor Necessity]]\n",
+            "- [[Unowned but Necessary]]\n",
+            "- [[Unowned]]\n"
+          ]
+        end
       end
     end
 
@@ -89,44 +121,76 @@ class HomeTest < ApplicationTest
 
   module Japanese
     class OwnedHomeTest < HomeTest
-      def setup
-        super(language: 'Japanese')
+      class NonOverflowTest < HomeTest
+        def setup
+          super(language: 'Japanese')
+        end
+
+        def test_self_run
+          assert_equal(home_passage.join, home)
+        end
+
+        private
+
+        def home_passage
+          [
+            "## Wiki ページの運用ルール\n",
+            "\n",
+            "このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n",
+            "\n",
+            "Ownership をどのチームが持つのかが不明だと、責任の所在が不明瞭になり、保守性の悪化に伴うノイズの増加と検索性の悪化が発生します。  \n",
+            "治安維持のため、各ページの冒頭に `Owner: @オーナーチーム` を明記して頂きますようよろしくお願いします。\n",
+            "\n",
+            "なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n",
+            "\n",
+            "## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n",
+            "\n",
+            "- [[Owner記名ありページ]]\n",
+            "\n",
+            "## Ownerチームが不明だが必要なページ群\n",
+            "\n",
+            "- [[Ownerチームが不明だが必要なページ]]\n",
+            "\n",
+            "## Ownerチーム・要or不要が不明なページ群\n",
+            "\n",
+            "- [[Ownerチーム・要or不要が不明なページ]]\n",
+            "\n",
+            "## Owner記名なし\n",
+            "\n",
+            "- [[Owner記名なしページ1]]\n",
+            "- [[Owner記名なしページ2]]\n"
+          ]
+        end
       end
 
-      def test_self_run
-        assert_equal(home_passage.join, home)
-      end
+      class OverflowTest < HomeTest
+        def setup
+          super(language: 'Japanese', home_overflow: true)
+        end
 
-      private
+        def test_self_run
+          assert_equal(home_passage.join, home)
+        end
 
-      def home_passage
-        [
-          "## Wiki ページの運用ルール\n",
-          "\n",
-          "このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n",
-          "\n",
-          "Ownership をどのチームが持つのかが不明だと、責任の所在が不明瞭になり、保守性の悪化に伴うノイズの増加と検索性の悪化が発生します。  \n",
-          "治安維持のため、各ページの冒頭に `Owner: @オーナーチーム` を明記して頂きますようよろしくお願いします。\n",
-          "\n",
-          "なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n",
-          "\n",
-          "## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n",
-          "\n",
-          "- [[Owner記名ありページ]]\n",
-          "\n",
-          "## Ownerチームが不明だが必要なページ群\n",
-          "\n",
-          "- [[Ownerチームが不明だが必要なページ]]\n",
-          "\n",
-          "## Ownerチーム・要or不要が不明なページ群\n",
-          "\n",
-          "- [[Ownerチーム・要or不要が不明なページ]]\n",
-          "\n",
-          "## Owner記名なし\n",
-          "\n",
-          "- [[Owner記名なしページ1]]\n",
-          "- [[Owner記名なしページ2]]\n"
-        ]
+        private
+
+        def home_passage
+          [
+            "## Wiki ページの運用ルール\n",
+            "\n",
+            "このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n",
+            "\n",
+            "Ownership をどのチームが持つのかが不明だと、責任の所在が不明瞭になり、保守性の悪化に伴うノイズの増加と検索性の悪化が発生します。  \n",
+            "治安維持のため、各ページの冒頭に `Owner: @オーナーチーム` を明記して頂きますようよろしくお願いします。\n",
+            "\n",
+            "なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n",
+            "\n",
+            "- [[@test-owner]]\n",
+            "- [[Ownerチームが不明だが必要なページ群]]\n",
+            "- [[Ownerチーム・要or不要が不明なページ群]]\n",
+            "- [[Owner記名なし]]\n"
+          ]
+        end
       end
     end
 

--- a/ruby/test/home_test.rb
+++ b/ruby/test/home_test.rb
@@ -2,9 +2,9 @@ require_relative './application_test'
 require_relative '../src/home'
 
 class HomeTest < ApplicationTest
-  def setup(group_by: 'Owner', language: 'English')
-    super(group_by:, language:)
-    Home.run(base_path:, group_by:, language:)
+  def setup(group_by: 'Owner', language: 'English', home_overflow: false)
+    super(group_by:, language:, home_overflow:)
+    Home.run(base_path:, group_by:, language:, home_overflow:)
     @path_to_home = File.join(base_path, 'Home.md')
     @home         = File.read(path_to_home)
   end


### PR DESCRIPTION
## 1. Summary

Home fails to render the page if there are too many contents.

<img width="888" height="424" alt="Screenshot 2025-08-16 022800" src="https://github.com/user-attachments/assets/4602d922-d9a0-4fdf-a684-ed846231bb22" />

It is terribly a user-unfriendly experince, so it must be optimised.

## 2. Counter-measure

1. Addeda new parameter on GHA workflow_disppatch, `home_overflow`. If a user find the warning "⚠️ The wiki page took too long to render.", they should select `True`. Otherwise, `False` is expected to be set.
2. If `home_overflow == true`, the only thing Home does is to list owners with link to their wiki lists. The wiki list files are placed under `./wikis_by_owner/` directory.
3. It will succeed in properly showing Home page even if there are so many wiki pages are present by bypassing wiki lists by owners.

## 3. Commits

- [Add new parameter home_overflow to GHA workflow_dispatch](https://github.com/hayat01sh1da/github-wiki-organisers/commit/28e06b861b15ded0b43452aad2350002a2224b6d)
- [Optimise Ruby I/Fs for newly added argument home_overflow](https://github.com/hayat01sh1da/github-wiki-organisers/commit/34c08b60ea9342e1bc441d04c726a06bef625e0e)
- [Optimise Python I/Fs for newly added argument home_overflow](https://github.com/hayat01sh1da/github-wiki-organisers/commit/5bf4319328d604cad3e3b620e9b70175966bdf54)
- [Commit unit tests and adjust implements](https://github.com/hayat01sh1da/github-wiki-organisers/commit/39ab052e932b110ada0a10bd3af67a50d9f88e17)
- [Optimise execution filles](https://github.com/hayat01sh1da/github-wiki-organisers/commit/15c1785ed1277109ab2d39d4a09ccad3486d062e)
- [Describe newly added parameter on READMEs](https://github.com/hayat01sh1da/github-wiki-organisers/commit/6d3405583aa29fab3391641e78418bdd2aa21223)